### PR TITLE
Handle attribute values containing `>`

### DIFF
--- a/l3wrapper/__init__.py
+++ b/l3wrapper/__init__.py
@@ -12,7 +12,7 @@ import zipfile
 import stat
 
 
-__version__ = '0.6.1'
+__version__ = '0.6.2'
 __author__ = 'Giuseppe Attanasio <giuseppe.attanasio@polito.it>'
 __all__ = []
 

--- a/l3wrapper/dictionary.py
+++ b/l3wrapper/dictionary.py
@@ -125,7 +125,8 @@ def build_item_dictionaries(filestem: str) -> (dict, dict):
         for line in lines:
             tok = line.split('->')               # e.g. 74->21,2
             item_id = int(tok[0])
-            attrid_val_pair = tok[1].split(',')
+            right_end = "->".join(tok[1:])
+            attrid_val_pair = right_end.split(',')
             
             # L3 uses a 1-based positional indexing, hence save 'column_id' as 'attr_pos - 1'
             attr_pos = int(attrid_val_pair[0])

--- a/l3wrapper/dictionary.py
+++ b/l3wrapper/dictionary.py
@@ -123,8 +123,8 @@ def build_item_dictionaries(filestem: str) -> (dict, dict):
     with open(f"{filestem}.diz", "r") as fp:
         lines = [l.strip('\n') for l in fp.readlines()]
         for line in lines:
-            tok = line.split('>')               # e.g. 74->21,2
-            item_id = int(tok[0][:-1])
+            tok = line.split('->')               # e.g. 74->21,2
+            item_id = int(tok[0])
             attrid_val_pair = tok[1].split(',')
             
             # L3 uses a 1-based positional indexing, hence save 'column_id' as 'attr_pos - 1'

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read(filename):
 
 setup(
     name="l3wrapper",
-    version="0.6.1",
+    version="0.6.2",
     url="https://github.com/g8a9/l3wrapper",
     license='MIT',
 
@@ -28,7 +28,7 @@ setup(
 
     packages=find_packages(exclude=('tests',)),
 
-    install_requires=['numpy', 'sklearn'],
+    install_requires=['numpy', 'scikit-learn'],
 
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
 
     packages=find_packages(exclude=('tests',)),
 
-    install_requires=['numpy', 'sklearn'],
+    install_requires=['numpy', 'sklearn', 'tqdm, 'requests'],
 
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
If a rule line is e.g. `11->11,>=51` then it will be parsed incorrectly and `item_id_to_item` will contain `''` instead of `>=51`.